### PR TITLE
Avoid overriding the purposes attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ These operations take place in accordance with the rules explained in [this guid
 
 ## Changelog
 
+##### 4.1.8
+* Fix: Avoid overriding the purposes attr if it was set
+
 ##### 4.1.7
 * Fix: purpose evaluation for iframes blocking
 

--- a/iubenda.class.php
+++ b/iubenda.class.php
@@ -510,9 +510,7 @@ class iubendaParser {
 									$this->scripts_inline_converted[] = $s->innertext;
 
 									// add data-iub-purposes attribute
-									if ( ! $s->hasAttribute( 'data-iub-purposes' ) ) {
-										$s->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found, $this->script_tags ) );
-									}
+									$this->set_purpose($s, $found);
 
 									# Run observers
 									$this->run_observers( $found, $s );
@@ -531,9 +529,7 @@ class iubendaParser {
 										$s->type = 'text/plain';
 
 										// add data-iub-purposes attribute
-										if ( ! $s->hasAttribute( 'data-iub-purposes' ) ) {
-											$s->{'data-iub-purposes'} = $this->recursive_array_search( $found, $this->script_tags );
-										}
+										$this->set_purpose($s, $found);
 
 										// AMP support
 										if ( $this->amp )
@@ -697,9 +693,7 @@ class iubendaParser {
 							$script->setAttribute( 'class', $script->getAttribute( 'class' ) . ' ' . $class );
 
 							// add data-iub-purposes attribute
-							if ( ! $script->hasAttribute( 'data-iub-purposes' ) ) {
-								$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found, $this->script_tags ) );
-							}
+							$this->set_purpose( $script, $found );
 
 							// AMP support
 							if ( $this->amp )
@@ -719,9 +713,7 @@ class iubendaParser {
 								$script->setAttribute( 'data-block-on-consent', '_till_accepted' );
 
 							// add data-iub-purposes attribute
-							if ( ! $script->hasAttribute( 'data-iub-purposes' ) ) {
-								$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found_inline, $this->script_tags ) );
-							}
+							$this->set_purpose($script, $found_inline);
 
 							// Run observers
 							$this->run_observers( $found_inline, $script );
@@ -1086,6 +1078,18 @@ class iubendaParser {
 			require_once "listeners/{$class}.php";
 			$listener_instance = new $class( $script, $this );
 			$listener_instance->handle();
+		}
+	}
+
+	/**
+	 * Set purpose on script tag if not exist
+	 *
+	 * @param $script
+	 * @param $url
+	 */
+	private function set_purpose( $script, $url ) {
+		if ( ! $script->hasAttribute( 'data-iub-purposes' ) ) {
+			$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $url, $this->script_tags ) );
 		}
 	}
 }

--- a/iubenda.class.php
+++ b/iubenda.class.php
@@ -5,7 +5,7 @@
  * @author iubenda s.r.l
  * @copyright 2018-2020, iubenda s.r.l
  * @license GNU/GPL
- * @version 4.1.7
+ * @version 4.1.8
  * @deprecated
  *
  * This program is free software: you can redistribute it and/or modify
@@ -510,7 +510,9 @@ class iubendaParser {
 									$this->scripts_inline_converted[] = $s->innertext;
 
 									// add data-iub-purposes attribute
-									$s->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found, $this->script_tags ) );
+									if ( ! $s->hasAttribute( 'data-iub-purposes' ) ) {
+										$s->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found, $this->script_tags ) );
+									}
 
 									# Run observers
 									$this->run_observers( $found, $s );
@@ -529,7 +531,9 @@ class iubendaParser {
 										$s->type = 'text/plain';
 
 										// add data-iub-purposes attribute
-										$s->{'data-iub-purposes'} = $this->recursive_array_search( $found, $this->script_tags );
+										if ( ! $s->hasAttribute( 'data-iub-purposes' ) ) {
+											$s->{'data-iub-purposes'} = $this->recursive_array_search( $found, $this->script_tags );
+										}
 
 										// AMP support
 										if ( $this->amp )
@@ -693,7 +697,9 @@ class iubendaParser {
 							$script->setAttribute( 'class', $script->getAttribute( 'class' ) . ' ' . $class );
 
 							// add data-iub-purposes attribute
-							$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found, $this->script_tags ) );
+							if ( ! $script->hasAttribute( 'data-iub-purposes' ) ) {
+								$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found, $this->script_tags ) );
+							}
 
 							// AMP support
 							if ( $this->amp )
@@ -713,7 +719,9 @@ class iubendaParser {
 								$script->setAttribute( 'data-block-on-consent', '_till_accepted' );
 
 							// add data-iub-purposes attribute
-							$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found_inline, $this->script_tags ) );
+							if ( ! $script->hasAttribute( 'data-iub-purposes' ) ) {
+								$script->setAttribute( 'data-iub-purposes', $this->recursive_array_search( $found_inline, $this->script_tags ) );
+							}
 
 							// Run observers
 							$this->run_observers( $found_inline, $script );


### PR DESCRIPTION
# [Task URL](https://app.asana.com/0/home/1193378287746655/1199548900967068)
***
- [ ] Feature
- [ ] Enhancement
- [x] Bug 

#### Issue
- When using the shortcode `IUB-COOKIE-BLOCK-START-PURPOSE-2` to force 2 as pur-purpose on a script, The parser ignore it and set the proper purpose if it is already predefined in blocked scripts.

#### Proposed solution
- Check if the `data-iub-purposes` attribute is already defined before putting it.

### Issue example

```javascript
<!--IUB-COOKIE-BLOCK-START-PURPOSE-2-->
    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22651853-1" type="text/javascript"></script>
    <script>
        window.dataLayer = window.dataLayer || [];
        function gtag(){dataLayer.push(arguments);}
        gtag('js', new Date());
        gtag('config', 'UA-22651853-1');
    </script>
<!--IUB-COOKIE-BLOCK-END-PURPOSE-2-->
```
